### PR TITLE
CI: fail when wasmtime fails to download

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Setup wasm32-wasi
       run: rustup target add wasm32-wasi
     - name: Setup wasmtime
-      run: curl https://wasmtime.dev/install.sh -sSf | bash
+      run: |
+        set -o pipefail
+        curl https://wasmtime.dev/install.sh -sSf | bash
     - name: Test
       run: CARGO_TARGET_WASM32_WASI_RUNNER="/home/runner/.wasmtime/bin/wasmtime --invoke _start --allow-unknown-exports" cargo test --target=wasm32-wasi --all-targets
 


### PR DESCRIPTION
Recently, we got a CI failure because wasmtime failed to download. The wasmtime installer uses the `curl | bash` pattern. However, by default in bash (and in our CI) the return status of a pipeline is the same as the return status of the last command - and if curl doesn't output anything then the bash invocation will succeed.

In order to prevent the CI from continuing after a curl error, we need to set the `pipefail` option which changes bash's behavior - if set, pipelines return the status code of the rightmost _failed_ command in the pipeline. This commit sets this option in the step which installs wasmtime.